### PR TITLE
fix cronjob id

### DIFF
--- a/cronjobs/cronjobs.go
+++ b/cronjobs/cronjobs.go
@@ -93,12 +93,16 @@ func AddCronjob(req *http.Request, params martini.Params, cronjob structs.Cronjo
 		return
 	}
 	fmt.Printf("%+v\n", cronjob)
+
+	iduuid, _ := uuid.NewV4()
+	cronjob.ID = iduuid.String()
 	err := addCronjob(req, cronjob)
 	if err != nil {
 		fmt.Println(berr)
 		r.JSON(500, map[string]interface{}{"response": err.Error()})
 		return
 	}
+
 	err = dbstore.AddCronJob(cronjob)
 	if err != nil {
 		fmt.Println(berr)

--- a/dbstore/cronjobs.go
+++ b/dbstore/cronjobs.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
-	uuid "github.com/nu7hatch/gouuid"
 )
 
 var cdb *sql.DB
@@ -137,8 +136,6 @@ func GetCronjobs() (j []structs.Cronjob, e error) {
 }
 
 func AddCronJob(cronjob structs.Cronjob) (e error) {
-	iduuid, _ := uuid.NewV4()
-	id := iduuid.String()
 	var stmtstring string = "insert into cronjobs (id, job,  jobspace, cronspec, command) values ($1,$2,$3,$4,$5)"
 
 	stmt, err := cdb.Prepare(stmtstring)
@@ -147,7 +144,7 @@ func AddCronJob(cronjob structs.Cronjob) (e error) {
 		return err
 	}
 
-	_, inserterr := stmt.Exec(id, cronjob.Job, cronjob.Jobspace, cronjob.Cronspec, cronjob.Command)
+	_, inserterr := stmt.Exec(cronjob.ID, cronjob.Job, cronjob.Jobspace, cronjob.Cronspec, cronjob.Command)
 	if inserterr != nil {
 		fmt.Println(inserterr)
 		return inserterr


### PR DESCRIPTION
The cronjob ID was assigned after being added to the cron utility, but before adding it to the database. This means that each job had an ID in the database but not in the cron utility.

When a cron job runs, the information is gathered from the cron utility and not the database, so each run never had the cron ID set.