### PR TITLE
Add webhooks and PREVIEW_SITES, AKKERIS_CI env vars

### DIFF
--- a/create.sql
+++ b/create.sql
@@ -24,12 +24,14 @@ CREATE TABLE IF NOT EXISTS diagnostics (
     command text,
     testpreviews boolean,
     ispreview boolean,
+    webhookurls text,
     CONSTRAINT diagnostics_space_app_result_action_job_jobspace_key UNIQUE (space, app, result, action, job, jobspace)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS diagnostics_pkey ON diagnostics(id text_ops);
 ALTER TABLE diagnostics ADD COLUMN IF NOT EXISTS command TEXT;
 ALTER TABLE diagnostics ADD COLUMN IF NOT EXISTS testpreviews BOOLEAN;
 ALTER TABLE diagnostics ADD COLUMN IF NOT EXISTS ispreview BOOLEAN;
+ALTER TABLE diagnostics ADD COLUMN IF NOT EXISTS webhookurls TEXT;
 
 CREATE TABLE IF NOT EXISTS promotions (
     id text NOT NULL,

--- a/dbstore/tests.go
+++ b/dbstore/tests.go
@@ -225,21 +225,21 @@ func isUUID(uuid string) bool {
 }
 
 func FindPreviewParentDiagnostic(app string) (d structs.DiagnosticSpec, e error) {
-	var selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false) from diagnostics where app||'-'||space = $1 and testpreviews = true"
+	var selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false), coalesce(webhookurls,null,'') from diagnostics where app||'-'||space = $1 and testpreviews = true"
 	return findDiagnostic(app, selectstring)
 }
 
 func FindDiagnosticByApp(app string) (d structs.DiagnosticSpec, e error) {
-	var selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false) from diagnostics where app||'-'||space = $1"
+	var selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false), coalesce(webhookurls,null,'') from diagnostics where app||'-'||space = $1"
 	return findDiagnostic(app, selectstring)
 }
 
 func FindDiagnostic(provided string) (d structs.DiagnosticSpec, e error) {
 	var selectstring string
 	if !isUUID(provided) {
-		selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false) from diagnostics where job||'-'||jobspace = $1"
+		selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false), coalesce(webhookurls,null,'') from diagnostics where job||'-'||jobspace = $1"
 	} else {
-		selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false) from diagnostics where id = $1"
+		selectstring = "select id, space, app, action, result, job, jobspace, image, pipelinename, transitionfrom, transitionto, timeout, startdelay, slackchannel, coalesce(command,null,''), coalesce(testpreviews,null,false), coalesce(ispreview,null,false), coalesce(webhookurls,null,'') from diagnostics where id = $1"
 	}
 	return findDiagnostic(provided, selectstring)
 }
@@ -277,11 +277,12 @@ func findDiagnostic(input string, selectstring string) (d structs.DiagnosticSpec
 	var dcommand string
 	var dtestpreviews bool
 	var dispreview bool
+	var dwebhookurls string
 
 	defer stmt.Close()
 	rows, err := stmt.Query(input)
 	for rows.Next() {
-		err := rows.Scan(&did, &dspace, &dapp, &daction, &dresult, &djob, &djobspace, &dimage, &dpipelinename, &dtransitionfrom, &dtransitionto, &dtimeout, &dstartdelay, &dslackchannel, &dcommand, &dtestpreviews, &dispreview)
+		err := rows.Scan(&did, &dspace, &dapp, &daction, &dresult, &djob, &djobspace, &dimage, &dpipelinename, &dtransitionfrom, &dtransitionto, &dtimeout, &dstartdelay, &dslackchannel, &dcommand, &dtestpreviews, &dispreview, &dwebhookurls)
 		if err != nil {
 			fmt.Println(err)
 			return diagnostic, err
@@ -303,6 +304,7 @@ func findDiagnostic(input string, selectstring string) (d structs.DiagnosticSpec
 		diagnostic.Command = dcommand
 		diagnostic.TestPreviews = dtestpreviews
 		diagnostic.IsPreview = dispreview
+		diagnostic.WebhookURLs = dwebhookurls
 		//runiduuid, _ := uuid.NewV4()
 		//runid := runiduuid.String()
 		//fmt.Println(runid)

--- a/notifications/webhooks.go
+++ b/notifications/webhooks.go
@@ -1,0 +1,120 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	structs "taas/structs"
+)
+
+// PromotionResults contains information on a triggered Akkeris app promotion
+type PromotionResults struct {
+	Message  string `json:"message"`
+	Pipeline string `json:"pipeline"`
+	From     string `json:"from"`
+	To       string `json:"to"`
+	Status   string `json:"status"`
+}
+
+// WebhookPayload is the structure of the message to be sent as a webhook
+type WebhookPayload struct {
+	Job              string           `json:"job"`
+	Target           string           `json:"target"`
+	Status           string           `json:"status"`
+	IsPreview        bool             `json:"ispreview"`
+	IsCron           bool             `json:"iscron"`
+	LogURL           string           `json:"log_url"`
+	KibanaURL        string           `json:"kibana_url"`
+	ArtifactsURL     string           `json:"artifacts_url"`
+	GithubVersion    string           `json:"github_version"`
+	RerunURL         string           `json:"rerun_url"`
+	CommitAuthor     string           `json:"commit_author"`
+	StartTime        string           `json:"start_time"`
+	StopTime         string           `json:"stop_time"`
+	RunDurationMs    int64            `json:"run_duration_ms"`
+	PromotionResults PromotionResults `json:"promotion_results"`
+}
+
+// PostWebhooks sends test results to the user-configured webhooks (if any)
+func PostWebhooks(diagnostic structs.DiagnosticSpec, status string, promotestatus string, isCron bool, result structs.ResultSpec) error {
+	// No configured webhook destinations
+	if diagnostic.WebhookURLs == "" {
+		return nil
+	}
+
+	// Assemble the webhook payload
+	payload := WebhookPayload{
+		Job:              diagnostic.JobSpace + "/" + diagnostic.Job,
+		Target:           diagnostic.App + "-" + diagnostic.Space,
+		Status:           status,
+		IsPreview:        diagnostic.IsPreview,
+		IsCron:           isCron,
+		LogURL:           os.Getenv("LOG_URL") + "/logs/" + diagnostic.RunID,
+		KibanaURL:        os.Getenv("KIBANA_URL") + "/app/kibana#/doc/logs/logs/run/?id=" + diagnostic.RunID,
+		ArtifactsURL:     os.Getenv("ARTIFACTS_URL") + "/v1/artifacts/" + diagnostic.RunID + "/",
+		RerunURL:         os.Getenv("RERUN_URL") + "?space=" + diagnostic.Space + "&app=" + diagnostic.App + "&action=" + diagnostic.Action + "&result=" + diagnostic.Result + "&releaseid=" + diagnostic.ReleaseID + "&buildid=" + diagnostic.BuildID,
+		CommitAuthor:     diagnostic.CommitAuthor,
+		StartTime:        result.Payload.StartTime,
+		StopTime:         result.Payload.StopTime,
+		RunDurationMs:    result.Payload.BuildTimeMillis,
+		PromotionResults: PromotionResults{},
+	}
+
+	if diagnostic.GithubVersion != "" {
+		payload.GithubVersion = diagnostic.GithubVersion
+	}
+
+	if status != "success" {
+		payload.PromotionResults.Message = "No promotion triggered - tests not successful"
+	} else if diagnostic.PipelineName == "manual" {
+		payload.PromotionResults.Message = "No promotion triggered - set to manual"
+		payload.PromotionResults.Pipeline = diagnostic.PipelineName
+	} else {
+		payload.PromotionResults.Message = "Promotion was triggered with result " + promotestatus
+		payload.PromotionResults.Status = promotestatus
+		payload.PromotionResults.From = diagnostic.TransitionFrom
+		payload.PromotionResults.To = diagnostic.TransitionTo
+		payload.PromotionResults.Pipeline = diagnostic.PipelineName
+	}
+
+	// Send message to each hook URL
+	for _, hookURL := range strings.Split(diagnostic.WebhookURLs, ",") {
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		if !strings.HasPrefix(hookURL, "http://") && !strings.HasPrefix(hookURL, "https://") {
+			hookURL = "https://" + hookURL
+		}
+
+		req, err := http.NewRequest("POST", hookURL, bytes.NewBuffer(payloadBytes))
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+		req.Header.Add("Content-type", "application/json")
+
+		client := http.Client{}
+		_, err = client.Do(req)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		// If we ever want to save the result and do something with it
+		// defer resp.Body.Close()
+		// bodybytes, err := ioutil.ReadAll(resp.Body)
+		// if err != nil {
+		// 	fmt.Println(err)
+		// 	return err
+		// }
+		// fmt.Println(string(bodybytes))
+		// fmt.Println(resp.status)
+	}
+	return nil
+}

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -115,9 +115,9 @@ type ActionSpec struct {
 }
 
 type StepSpec struct {
-	Name    string       `json:"name"`
-        Organization string  `json:org"`
-	Actions []ActionSpec `json:"actions"`
+	Name         string       `json:"name"`
+	Organization string       `json:org"`
+	Actions      []ActionSpec `json:"actions"`
 }
 
 type ResultSpec struct {
@@ -176,6 +176,7 @@ type EnvironmentVariable struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
+
 type DiagnosticSpec struct {
 	ID             string                `json:"id"`
 	Space          string                `json:"space"`
@@ -204,6 +205,7 @@ type DiagnosticSpec struct {
 	TestPreviews   bool                  `json:"testpreviews"` // Run diagnostic on the app's preview apps
 	IsPreview      bool                  `json:"ispreview"`    // This diagnostic is for a preview app
 	Token          string                `json:"token"`
+	WebhookURLs    string                `json:"webhookurls"` // Comma-separated list of webhook URLs to notify with test results
 }
 
 type DiagnosticSpecAudit struct {


### PR DESCRIPTION
- Ability to provide a comma-separated list of webhooks to post test results to
- Add `PREVIEW_SITES` environment variable, which is a comma-separated list of all preview sites present in the `preview_created` hook
- Add `AKKERIS_CI=true` and `CI=true` environment variables to test runs

Future TODO: Make slack channel optional?