### PR TITLE
Cron Worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,3 @@ RUN go build .
 RUN chmod +x ./start.sh
 CMD ["./start.sh"]
 EXPOSE 4000
-

--- a/artifacts/upload.go
+++ b/artifacts/upload.go
@@ -1,43 +1,44 @@
 package artifacts
+
 import (
-        "github.com/aws/aws-sdk-go/aws"
-        "github.com/aws/aws-sdk-go/aws/awserr"
-        "github.com/aws/aws-sdk-go/aws/session"
-        "github.com/aws/aws-sdk-go/service/s3"
-        "fmt"
-        "bytes"
-        "os"
+	"bytes"
+	"fmt"
+	"os"
+	"taas/utils"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-
 func UploadToS3(body string, contenttype string, runid string) {
-stringBytes := bytes.NewReader([]byte(body))
+	stringBytes := bytes.NewReader([]byte(body))
 
-        svc := s3.New(session.New(&aws.Config{
-                Region: aws.String(os.Getenv("AWS_REGION")),
-        }))
+	svc := s3.New(session.New(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_REGION")),
+	}))
 
-input := &s3.PutObjectInput{
-    Body:   aws.ReadSeekCloser(stringBytes),
-    Bucket: aws.String(os.Getenv("AWS_S3_BUCKET")),
-    Key:    aws.String(runid+"/describe.txt"),
-    ContentType: aws.String(contenttype),
-}
+	input := &s3.PutObjectInput{
+		Body:        aws.ReadSeekCloser(stringBytes),
+		Bucket:      aws.String(os.Getenv("AWS_S3_BUCKET")),
+		Key:         aws.String(runid + "/describe.txt"),
+		ContentType: aws.String(contenttype),
+	}
 
-result, err := svc.PutObject(input)
-if err != nil {
-    if aerr, ok := err.(awserr.Error); ok {
-        switch aerr.Code() {
-        default:
-            fmt.Println(aerr.Error())
-        }
-    } else {
-        // Print the error, cast err to awserr.Error to get the Code and
-        // Message from an error.
-        fmt.Println(err.Error())
-    }
-    return
-}
-
-fmt.Println(result)
+	result, err := svc.PutObject(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			fmt.Println(err.Error())
+		}
+		return
+	}
+	utils.PrintDebug(result)
 }

--- a/auth/user.go
+++ b/auth/user.go
@@ -2,12 +2,13 @@ package auth
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	structs "taas/structs"
-        "fmt"
+	"taas/utils"
 )
 
 func GetUser(req *http.Request) (u string, e error) {
@@ -17,7 +18,7 @@ func GetUser(req *http.Request) (u string, e error) {
 		return "nouser", err
 	}
 	req.Header.Set("Authorization", authheader)
-        req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", "application/json")
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -33,14 +34,16 @@ func GetUser(req *http.Request) (u string, e error) {
 	if err != nil {
 		return "nouser", err
 	}
-fmt.Println("*************************************USER********************************")
-fmt.Printf("%+v\n", user)
-fmt.Println("*************************************USER********************************")
-        if user.Email != "" {
-	   return user.Email, nil
-        }
-        if user.Cn != "" {
-           return user.Cn, nil
-        }
-        return "nouser", nil
+
+	utils.PrintDebug("*************************************USER********************************")
+	userstr := fmt.Sprintf("%+v\n", user)
+	utils.PrintDebug(userstr)
+	utils.PrintDebug("*************************************USER********************************")
+	if user.Email != "" {
+		return user.Email, nil
+	}
+	if user.Cn != "" {
+		return user.Cn, nil
+	}
+	return "nouser", nil
 }

--- a/cronjobs/cronjobs.go
+++ b/cronjobs/cronjobs.go
@@ -112,7 +112,7 @@ func AddCronjob(req *http.Request, params martini.Params, cronjob structs.Cronjo
 	if os.Getenv("ENABLE_CRON_WORKER") == "" {
 		err := addCronjob(req, cronjob)
 		if err != nil {
-			fmt.Println(berr)
+			fmt.Println(err)
 			r.JSON(500, map[string]interface{}{"response": err.Error()})
 			return
 		}
@@ -120,7 +120,7 @@ func AddCronjob(req *http.Request, params martini.Params, cronjob structs.Cronjo
 
 	err := dbstore.AddCronJob(cronjob)
 	if err != nil {
-		fmt.Println(berr)
+		fmt.Println(err)
 		r.JSON(500, map[string]interface{}{"response": err})
 		return
 	}
@@ -128,11 +128,16 @@ func AddCronjob(req *http.Request, params martini.Params, cronjob structs.Cronjo
 }
 
 func addCronjob(req *http.Request, cronjob structs.Cronjob) (e error) {
+	if cronjob.Cronspec == "" {
+		return errors.New("Cronspec must be provided")
+	}
+
 	diagnostic, err := dbstore.FindDiagnostic(cronjob.Job + "-" + cronjob.Jobspace)
 	if err != nil {
 		fmt.Println(err)
 		return err
 	}
+
 	runiduuid, _ := uuid.NewV4()
 	runid := runiduuid.String()
 	diagnostic.RunID = runid

--- a/cronjobs/cronjobs.go
+++ b/cronjobs/cronjobs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	dbstore "taas/dbstore"
 	diagnostics "taas/diagnostics"
@@ -13,7 +14,7 @@ import (
 	"github.com/martini-contrib/binding"
 	"github.com/martini-contrib/render"
 	uuid "github.com/nu7hatch/gouuid"
-        "github.com/robfig/cron/v3"
+	"github.com/robfig/cron/v3"
 )
 
 var Cronjob *cron.Cron
@@ -70,6 +71,17 @@ func GetCronjobRuns(req *http.Request, params martini.Params, r render.Render) {
 }
 
 func GetCronjobs(params martini.Params, r render.Render) {
+	if os.Getenv("ENABLE_CRON_WORKER") != "" {
+		cronjobs, err := dbstore.GetCronjobsWithSchedule()
+		if err != nil {
+			fmt.Println(err)
+			r.JSON(500, map[string]interface{}{"response": err})
+			return
+		}
+		r.JSON(200, cronjobs)
+		return
+	}
+
 	var cronjobs []structs.Cronjob
 	var newlist []structs.Cronjob
 	cronjobs, err := dbstore.GetCronjobs()
@@ -92,18 +104,21 @@ func AddCronjob(req *http.Request, params martini.Params, cronjob structs.Cronjo
 		r.JSON(500, map[string]interface{}{"response": berr})
 		return
 	}
-	fmt.Printf("%+v\n", cronjob)
 
 	iduuid, _ := uuid.NewV4()
 	cronjob.ID = iduuid.String()
-	err := addCronjob(req, cronjob)
-	if err != nil {
-		fmt.Println(berr)
-		r.JSON(500, map[string]interface{}{"response": err.Error()})
-		return
+
+	// Not using cron worker. Add to internal cron scheduler
+	if os.Getenv("ENABLE_CRON_WORKER") == "" {
+		err := addCronjob(req, cronjob)
+		if err != nil {
+			fmt.Println(berr)
+			r.JSON(500, map[string]interface{}{"response": err.Error()})
+			return
+		}
 	}
 
-	err = dbstore.AddCronJob(cronjob)
+	err := dbstore.AddCronJob(cronjob)
 	if err != nil {
 		fmt.Println(berr)
 		r.JSON(500, map[string]interface{}{"response": err})
@@ -155,8 +170,12 @@ func deleteCronjob(req *http.Request, id string) (e error) {
 		return err
 	}
 
-	Cronjob.Remove(jobmap[cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec])
-	delete(jobmap, cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec)
+	// Not using cron worker. Remove from internal scheduler
+	if os.Getenv("ENABLE_CRON_WORKER") == "" {
+		Cronjob.Remove(jobmap[cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec])
+		delete(jobmap, cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec)
+	}
+
 	err = dbstore.DeleteCronjob(id)
 	if err != nil {
 		fmt.Println(err)
@@ -169,4 +188,57 @@ func deleteCronjob(req *http.Request, id string) (e error) {
 	}
 	dbstore.AddCronjobDeleteAudit(req, diagnostic.ID, cronjob)
 	return nil
+}
+
+// UpdateCronjob updates the configuration for a cronjob
+func UpdateCronjob(req *http.Request, params martini.Params, cronjob structs.Cronjob, berr binding.Errors, r render.Render) {
+	if berr != nil {
+		fmt.Println(berr)
+		r.JSON(500, map[string]interface{}{"response": berr})
+		return
+	}
+
+	err := updateCronjob(req, params["id"], cronjob)
+	if err != nil {
+		fmt.Println(err)
+		r.JSON(500, map[string]interface{}{"response": err.Error()})
+		return
+	}
+
+	r.JSON(200, map[string]interface{}{"status": "updated"})
+}
+
+// updateCronjob currently only handles updates to disabled toggle (maintenance mode)
+func updateCronjob(req *http.Request, id string, cronjob structs.Cronjob) (e error) {
+	oldJob, err := dbstore.GetCronjobByID(id)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return errors.New("The specified cron job does not exist")
+		}
+		return err
+	}
+
+	if oldJob.Disabled != cronjob.Disabled {
+		err := dbstore.UpdateCronjob(id, cronjob.Disabled)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetCronjob gets a single cronjob from the database
+func GetCronjob(req *http.Request, params martini.Params, r render.Render) {
+	cronjob, err := dbstore.GetCronjobByID(params["id"])
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			r.JSON(500, map[string]interface{}{"response": "The specified cron job does not exist"})
+			return
+		}
+		fmt.Println(err)
+		r.JSON(500, map[string]interface{}{"response": err.Error()})
+		return
+	}
+
+	r.JSON(200, cronjob)
 }

--- a/cronworker/cronworker.go
+++ b/cronworker/cronworker.go
@@ -89,21 +89,22 @@ func Start() {
 }
 
 // Handle incoming database messages
+// Adapted from https://coussej.github.io/2015/09/15/Listening-to-generic-JSON-notifications-from-PostgreSQL-in-Go/
 func waitForChanges() {
 	for {
 		select {
 
 		// Message received
-		case n := <-listener.Notify:
-			// n will be nil when the connection was reestablished
-			if n == nil {
+		case notification := <-listener.Notify:
+			// notification will be nil when the connection was reestablished
+			if notification == nil {
 				fmt.Println("[cron_worker]: Connection reestablished")
 				return
 			}
 
 			// Unmarshal to struct
 			var msg incomingMessage
-			err := json.Unmarshal([]byte(n.Extra), &msg)
+			err := json.Unmarshal([]byte(notification.Extra), &msg)
 			if err != nil {
 				fmt.Println("Error unmarshalling JSON: ", err)
 				return

--- a/cronworker/cronworker.go
+++ b/cronworker/cronworker.go
@@ -181,7 +181,6 @@ func addCronjob(cronjob structs.Cronjob) (e error) {
 func deleteCronjob(oldRecord structs.Cronjob) {
 	// Disabled jobs won't be in the scheduler
 	if oldRecord.Disabled {
-		fmt.Println("[cron_worker]: An unscheduled job was removed from the database (" + oldRecord.ID + ")")
 		return
 	}
 	fmt.Println("[cron_worker]: Removing cronjob " + oldRecord.Job + "-" + oldRecord.Jobspace + " (" + oldRecord.ID + ")")

--- a/cronworker/cronworker.go
+++ b/cronworker/cronworker.go
@@ -1,0 +1,208 @@
+package cronworker
+
+import (
+	"encoding/json"
+	"fmt"
+	"taas/dbstore"
+	"taas/diagnostics"
+	"taas/structs"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/robfig/cron/v3"
+	uuid "github.com/satori/go.uuid"
+)
+
+/*
+	The cron worker is only responsible for scheduling and running cron diagnostics.
+	It does not update configuration or add new cron jobs to the database.
+
+	It listens to the diagnosticdb using the Postgres NOTIFY/LISTEN pattern.
+	When records change in the cronjob table, it updates the internal cron scheduler.
+*/
+
+// Incoming message from the Postgres database
+// Indicates a database record has changed
+type incomingMessage struct {
+	Table  string `json:"table"`
+	Action string `json:"action"`
+	Data   struct {
+		OldRecord structs.Cronjob `json:"old_record"`
+		NewRecord structs.Cronjob `json:"new_record"`
+	} `json:"data"`
+}
+
+var cronScheduler *cron.Cron
+var jobmap map[string]cron.EntryID
+var listener *pq.Listener
+
+// Start starts the cron scheduler and listens for changed database records
+func Start() {
+	fmt.Println("[cron_worker]: Initializing...")
+
+	// Initialize the cron scheduler
+	cronScheduler = cron.New()
+	cronScheduler.Start()
+
+	dbstore.InitCronjobPool()
+
+	jobmap = make(map[string]cron.EntryID)
+
+	// Remove any old scheduled runs in database
+	err := dbstore.DeleteAllCronScheduleEntries()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Get a list of current database entries and add to cron scheduler
+	fmt.Println("[cron_worker]: Adding existing cronjobs from the database (if any)...")
+	var cronjobs []structs.Cronjob
+	cronjobs, err = dbstore.GetCronjobs()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	for _, element := range cronjobs {
+		if element.Disabled {
+			continue
+		}
+		err := addCronjob(element)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	// Create database listener
+	listener = dbstore.CreateListener()
+	err = listener.Listen("events")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("[cron_worker]: Initialization complete!")
+	fmt.Println("[cron_worker]: Watching for database changes...")
+
+	// Wait and handle new messages from the database
+	for {
+		waitForChanges()
+	}
+}
+
+// Handle incoming database messages
+func waitForChanges() {
+	for {
+		select {
+
+		// Message received
+		case n := <-listener.Notify:
+			// n will be nil when the connection was reestablished
+			if n == nil {
+				fmt.Println("[cron_worker]: Connection reestablished")
+				return
+			}
+
+			// Unmarshal to struct
+			var msg incomingMessage
+			err := json.Unmarshal([]byte(n.Extra), &msg)
+			if err != nil {
+				fmt.Println("Error unmarshalling JSON: ", err)
+				return
+			}
+
+			fmt.Println()
+			if msg.Action == "DELETE" {
+				deleteCronjob(msg.Data.OldRecord)
+			} else if msg.Action == "INSERT" {
+				addCronjob(msg.Data.NewRecord)
+			} else if msg.Action == "UPDATE" {
+				updateCronjob(msg.Data.OldRecord, msg.Data.NewRecord)
+			}
+
+			return
+
+		// It's been a while since we talked to the database, check and make sure we're still connected
+		case <-time.After(90 * time.Second):
+			go func() {
+				err := listener.Ping()
+				if err != nil {
+					fmt.Println("Error checking database connection: " + err.Error())
+				}
+			}()
+			return
+		}
+	}
+}
+
+// Add a new cron job to the scheduler
+func addCronjob(cronjob structs.Cronjob) (e error) {
+	// Should not add disabled jobs to the scheduler
+	if cronjob.Disabled {
+		return nil
+	}
+	fmt.Println("[cron_worker]: Scheduling cronjob for " + cronjob.Job + "-" + cronjob.Jobspace + " (" + cronjob.ID + ")...")
+
+	diagnostic, err := dbstore.FindDiagnostic(cronjob.Job + "-" + cronjob.Jobspace)
+	if err != nil {
+		fmt.Println("\n" + err.Error())
+		return err
+	}
+
+	runid := uuid.NewV4()
+	diagnostic.RunID = runid.String()
+
+	entryid, err := cronScheduler.AddFunc(cronjob.Cronspec, func() {
+		entryid := jobmap[cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec]
+		diagnostics.RunDiagnostic(diagnostic, true, cronjob)
+		err := dbstore.UpdateCronScheduleEntry(cronjob.ID, cronScheduler.Entry(entryid).Next, cronScheduler.Entry(entryid).Prev)
+		if err != nil {
+			fmt.Println("\nError updating scheduler information in the database")
+			fmt.Println(err)
+		}
+	})
+
+	if err != nil {
+		fmt.Println("\n" + err.Error())
+		return err
+	}
+
+	jobmap[cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec] = entryid
+
+	err = dbstore.InsertCronScheduleEntry(cronjob.ID, cronScheduler.Entry(entryid).Next, cronScheduler.Entry(entryid).Prev)
+	if err != nil {
+		fmt.Println("\nError adding scheduler information to the database")
+		fmt.Println(err)
+	}
+
+	fmt.Println("[cron_worker]: Cronjob added! Next run in " + time.Until(cronScheduler.Entry(entryid).Next).String())
+	return nil
+}
+
+// Remove a cron job from the scheduler
+func deleteCronjob(oldRecord structs.Cronjob) {
+	// Disabled jobs won't be in the scheduler
+	if oldRecord.Disabled {
+		fmt.Println("[cron_worker]: An unscheduled job was removed from the database (" + oldRecord.ID + ")")
+		return
+	}
+	fmt.Println("[cron_worker]: Removing cronjob " + oldRecord.Job + "-" + oldRecord.Jobspace + " (" + oldRecord.ID + ")")
+	cronScheduler.Remove(jobmap[oldRecord.Job+"-"+oldRecord.Jobspace+"-"+oldRecord.Cronspec])
+	delete(jobmap, oldRecord.Job+"-"+oldRecord.Jobspace+"-"+oldRecord.Cronspec)
+	err := dbstore.DeleteCronScheduleEntry(oldRecord.ID)
+	if err != nil {
+		fmt.Println("Error removing scheduler information from the database")
+		fmt.Println(err)
+	}
+	fmt.Println("[cron_worker]: Cronjob removed.")
+}
+
+// Update a cron job in the scheduler
+func updateCronjob(oldRecord structs.Cronjob, newRecord structs.Cronjob) {
+	fmt.Println("[cron_worker]: Cronjob " + oldRecord.ID + " has been updated. Removing old job from the schedule...")
+	deleteCronjob(oldRecord)
+	if newRecord.Disabled {
+		fmt.Println("[cron_worker]: Cronjob " + oldRecord.ID + " was disabled, not rescheduling.")
+	} else {
+		addCronjob(newRecord)
+	}
+	fmt.Println("[cron_worker]: Update complete.")
+}

--- a/dbstore/audits.go
+++ b/dbstore/audits.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	structs "taas/structs"
+	"taas/utils"
 
 	"database/sql"
 	"net/http"
@@ -81,7 +82,7 @@ func AddDiagnosticDeleteAudit(req *http.Request, diagnostic structs.DiagnosticSp
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey, newvalue) values ($1,$2,$3,$4,$5,$6)"
 
@@ -112,7 +113,7 @@ func AddDiagnosticCreateAudit(req *http.Request, diagnostic structs.DiagnosticSp
 	diagnosticaudit.Timeout = diagnostic.Timeout
 	diagnosticaudit.Startdelay = diagnostic.Startdelay
 	diagnosticaudit.Slackchannel = diagnostic.Slackchannel
-        diagnosticaudit.Command = diagnostic.Command
+	diagnosticaudit.Command = diagnostic.Command
 	audituuid, _ := uuid.NewV4()
 	auditid := audituuid.String()
 	user, err := auth.GetUser(req)
@@ -123,7 +124,7 @@ func AddDiagnosticCreateAudit(req *http.Request, diagnostic structs.DiagnosticSp
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey, newvalue) values ($1,$2,$3,$4,$5, $6)"
 
@@ -149,7 +150,7 @@ func AddDiagnosticUpdateAudit(req *http.Request, diagnostic structs.DiagnosticSp
 	diagnosticaudit.Timeout = diagnostic.Timeout
 	diagnosticaudit.Startdelay = diagnostic.Startdelay
 	diagnosticaudit.Slackchannel = diagnostic.Slackchannel
-        diagnosticaudit.Command = diagnostic.Command
+	diagnosticaudit.Command = diagnostic.Command
 	audituuid, _ := uuid.NewV4()
 	auditid := audituuid.String()
 	user, err := auth.GetUser(req)
@@ -160,7 +161,7 @@ func AddDiagnosticUpdateAudit(req *http.Request, diagnostic structs.DiagnosticSp
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey, newvalue) values ($1,$2,$3,$4,$5,$6)"
 
@@ -222,44 +223,42 @@ func GetAudits(params martini.Params, r render.Render) {
 	r.JSON(200, audits)
 }
 
-
 func AddCronjobDeleteAudit(req *http.Request, id string, cronjob structs.Cronjob) {
-        audituuid, _ := uuid.NewV4()
-        auditid := audituuid.String()
-        user, err := auth.GetUser(req)
-        if err != nil {
-                fmt.Println(err)
-        }
-        var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey) values ($1,$2,$3,$4,$5)"
+	audituuid, _ := uuid.NewV4()
+	auditid := audituuid.String()
+	user, err := auth.GetUser(req)
+	if err != nil {
+		fmt.Println(err)
+	}
+	var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey) values ($1,$2,$3,$4,$5)"
 
-        stmt, err := db.Prepare(stmtstring)
-        if err != nil {
-                db.Close()
-        }
+	stmt, err := db.Prepare(stmtstring)
+	if err != nil {
+		db.Close()
+	}
 
-        _, inserterr := stmt.Exec(auditid, id, user, "cronjobdestroy", cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec)
-        if inserterr != nil {
-                fmt.Println(inserterr)
-        }
+	_, inserterr := stmt.Exec(auditid, id, user, "cronjobdestroy", cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec)
+	if inserterr != nil {
+		fmt.Println(inserterr)
+	}
 }
 
 func AddCronjobCreateAudit(req *http.Request, id string, cronjob structs.Cronjob) {
-        audituuid, _ := uuid.NewV4()
-        auditid := audituuid.String()
-        user, err := auth.GetUser(req)
-        if err != nil {
-                fmt.Println(err)
-        }
-        var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey) values ($1,$2,$3,$4,$5)"
+	audituuid, _ := uuid.NewV4()
+	auditid := audituuid.String()
+	user, err := auth.GetUser(req)
+	if err != nil {
+		fmt.Println(err)
+	}
+	var stmtstring string = "insert into audits (auditid,  id, audituser, audittype, auditkey) values ($1,$2,$3,$4,$5)"
 
-        stmt, err := db.Prepare(stmtstring)
-        if err != nil {
-                db.Close()
-        }
+	stmt, err := db.Prepare(stmtstring)
+	if err != nil {
+		db.Close()
+	}
 
-        _, inserterr := stmt.Exec(auditid, id, user, "cronjobcreate", cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec)
-        if inserterr != nil {
-                fmt.Println(inserterr)
-        }
+	_, inserterr := stmt.Exec(auditid, id, user, "cronjobcreate", cronjob.Job+"-"+cronjob.Jobspace+"-"+cronjob.Cronspec)
+	if inserterr != nil {
+		fmt.Println(inserterr)
+	}
 }
-

--- a/dbstore/tests.go
+++ b/dbstore/tests.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	akkeris "taas/jobs"
 	structs "taas/structs"
+	"taas/utils"
 
 	"encoding/json"
 	"encoding/xml"
@@ -66,7 +67,7 @@ func GetMostRecentReleaseID(diagnostic structs.DiagnosticSpec) (r string) {
 }
 
 func StoreRun(diagnostic structs.DiagnosticSpec) (e error) {
-	fmt.Println("Storing run " + diagnostic.RunID + " with status " + diagnostic.OverallStatus)
+	utils.PrintDebug("Storing run " + diagnostic.RunID + " with status " + diagnostic.OverallStatus)
 	uri := os.Getenv("DIAGNOSTICDB")
 	db, dberr := sql.Open("postgres", uri)
 	if dberr != nil {
@@ -94,7 +95,7 @@ func StoreRun(diagnostic structs.DiagnosticSpec) (e error) {
 }
 
 func UpdateRunStatus(diagnostic structs.DiagnosticSpec) (e error) {
-	fmt.Println("Updating run " + diagnostic.RunID + " with status " + diagnostic.OverallStatus)
+	utils.PrintDebug("Updating run " + diagnostic.RunID + " with status " + diagnostic.OverallStatus)
 	uri := os.Getenv("DIAGNOSTICDB")
 	db, dberr := sql.Open("postgres", uri)
 	if dberr != nil {
@@ -114,7 +115,7 @@ func UpdateRunStatus(diagnostic structs.DiagnosticSpec) (e error) {
 func StoreBits(req *http.Request, params martini.Params, r render.Render) {
 	runid := params["runid"]
 	format := req.URL.Query().Get("format")
-	fmt.Println(format)
+	utils.PrintDebug(format)
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		fmt.Println(err)

--- a/diagnosticlogs/diagnosticlogs.go
+++ b/diagnosticlogs/diagnosticlogs.go
@@ -276,6 +276,7 @@ func GetRuns(params martini.Params, r render.Render) {
 	if err != nil {
 		fmt.Println(err)
 		r.JSON(500, map[string]interface{}{"response": err.Error()})
+		return
 	}
 	r.JSON(200, runlist)
 }
@@ -391,6 +392,7 @@ func TailLogs(w http.ResponseWriter, req *http.Request, params martini.Params, r
 	if err != nil {
 		fmt.Println(err)
 		r.JSON(500, map[string]interface{}{"response": err})
+		return
 	}
 	if diagnostic.ID == "" {
 		r.JSON(500, map[string]interface{}{"response": "invalid test"})

--- a/diagnosticlogs/diagnosticlogs.go
+++ b/diagnosticlogs/diagnosticlogs.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	dbstore "taas/dbstore"
 	structs "taas/structs"
+	"taas/utils"
 	"time"
 
 	sarama "github.com/Shopify/sarama"
@@ -132,12 +133,12 @@ func WriteLogES(diagnostic structs.DiagnosticSpec, logs structs.LogLines) {
 		fmt.Println(err)
 		return
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 }
 
 func GetLogsES(params martini.Params, r render.Render) {
 	runid := params["runid"]
-	fmt.Println(runid)
+	utils.PrintDebug(runid)
 	url := os.Getenv("ES_URL") + "/logs/run/" + runid
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -186,7 +187,7 @@ func GetLogsES(params martini.Params, r render.Render) {
 
 func GetLogsESObj(params martini.Params, r render.Render) {
 	runid := params["runid"]
-	fmt.Println(runid)
+	utils.PrintDebug(runid)
 	url := os.Getenv("ES_URL") + "/logs/run/" + runid
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -266,7 +267,7 @@ func WriteLogESPost(eslogs structs.ESlogSpecIn1, berr binding.Errors, params mar
 		fmt.Println(err)
 		return
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 }
 
 func GetRuns(params martini.Params, r render.Render) {
@@ -301,7 +302,7 @@ func getRuns(job string, jobspace string) (rl structs.RunList, e error) {
 		fmt.Println(err)
 		return runlist, err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	var runs structs.RunsSpec
 	err = json.Unmarshal(bodybytes, &runs)
 	if err != nil {
@@ -310,12 +311,12 @@ func getRuns(job string, jobspace string) (rl structs.RunList, e error) {
 	}
 	for _, hit := range runs.Hits.Hits {
 		if hit.Source.Job == job && hit.Source.Jobspace == jobspace {
-			fmt.Println(hit.ID)
-			fmt.Println(hit.Source.Job + "-" + hit.Source.Jobspace)
-			fmt.Println(hit.Source.App + "-" + hit.Source.Space)
-			fmt.Println(hit.Source.Hrtimestamp)
-			fmt.Println(hit.Source.Overallstatus)
-			fmt.Println("buildid:" + hit.Source.BuildID)
+			utils.PrintDebug(hit.ID)
+			utils.PrintDebug(hit.Source.Job + "-" + hit.Source.Jobspace)
+			utils.PrintDebug(hit.Source.App + "-" + hit.Source.Space)
+			utils.PrintDebug(hit.Source.Hrtimestamp.String())
+			utils.PrintDebug(hit.Source.Overallstatus)
+			utils.PrintDebug("buildid:" + hit.Source.BuildID)
 			var run structs.Run
 			run.ID = hit.ID
 			run.App = hit.Source.App
@@ -328,7 +329,7 @@ func getRuns(job string, jobspace string) (rl structs.RunList, e error) {
 			runlist.Runs = append(runlist.Runs, run)
 		}
 	}
-	fmt.Println(runlist)
+	utils.PrintDebug(runlist)
 	var cutlist structs.RunList
 	endlen := 11
 	for index, element := range runlist.Runs {
@@ -350,7 +351,7 @@ func reverseRunList(input []structs.Run) []structs.Run {
 
 func GetRunInfo(params martini.Params, r render.Render) {
 	runid := params["runid"]
-	fmt.Println(runid)
+	utils.PrintDebug(runid)
 	url := os.Getenv("ES_URL") + "/logs/run/" + runid
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -379,13 +380,13 @@ func GetRunInfo(params martini.Params, r render.Render) {
 	}
 	var empty []string
 	logs.Source.Logs = empty
-	fmt.Println(logs)
+	utils.PrintDebug(logs)
 
 	r.JSON(200, logs)
 }
 
 func TailLogs(w http.ResponseWriter, req *http.Request, params martini.Params, r render.Render) {
-	fmt.Println(params["provided"])
+	utils.PrintDebug(params["provided"])
 	diagnostic, err := dbstore.FindDiagnostic(params["provided"])
 	if err != nil {
 		fmt.Println(err)

--- a/example-worker-manifest.yaml
+++ b/example-worker-manifest.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: taas-cron-worker
+  name: taas-cron-worker
+  namespace: akkeris-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: taas-cron-worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: taas-cron-worker
+      name: taas-cron-worker
+    spec:
+      containers:
+      - name: taas-cron-worker
+        image: akkeris/taas:release-163
+        command: ["./start.sh"]
+        args: ["cron"]
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: akkeris-system-iam
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: akkeris-system-iam
+        envFrom:
+        - configMapRef:
+            name: taas
+        imagePullPolicy: IfNotPresent
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30

--- a/githubapi/commit.go
+++ b/githubapi/commit.go
@@ -8,15 +8,15 @@ import (
 	"os"
 	"strings"
 	structs "taas/structs"
-
+	"taas/utils"
 )
 
 func GetCommitAuthor(version string) (s string, m string, e error) {
 
-	fmt.Println(version)
+	utils.PrintDebug(version)
 	newversion := strings.Replace(version, "https://github.com", "https://api.github.com/repos", -1)
 	newerversion := strings.Replace(newversion, "commit", "commits", -1)
-	fmt.Println(newerversion)
+	utils.PrintDebug(newerversion)
 	req, err := http.NewRequest("GET", newerversion, nil)
 	req.Header.Add("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
 	if err != nil {
@@ -35,14 +35,14 @@ func GetCommitAuthor(version string) (s string, m string, e error) {
 		fmt.Println(err)
 		return "", "", err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	var commitinfo structs.CommitSpec
 	err = json.Unmarshal(bodybytes, &commitinfo)
 	if err != nil {
 		fmt.Println(err)
 		return "", "", err
 	}
-	fmt.Println(commitinfo.Commit.Author.Name)
+	utils.PrintDebug(commitinfo.Commit.Author.Name)
 	//        return commitinfo.Commit.Author.Name, nil
 	return commitinfo.Author.Login, commitinfo.Commit.Message, nil
 

--- a/hooks/build.go
+++ b/hooks/build.go
@@ -22,7 +22,8 @@ func BuildHook(payload structs.BuildPayload, berr binding.Errors, r render.Rende
 		fmt.Println(berr)
 		return
 	}
-	spew.Dump(payload)
+	utils.PrintDebug(spew.Sdump(payload))
+
 	if payload.Build.Result != "pending" {
 		buildinfo, err := getBuildInfo(payload)
 		if err != nil {
@@ -36,7 +37,7 @@ func BuildHook(payload structs.BuildPayload, berr binding.Errors, r render.Rende
 			fmt.Println(err)
 		}
 		buildinfo.Organization = org
-		spew.Dump(buildinfo)
+		utils.PrintDebug(spew.Sdump(buildinfo))
 		err = writeBuildOutputES(buildinfo)
 		if err != nil {
 			fmt.Println(err)
@@ -82,7 +83,7 @@ func writeBuildOutputES(buildinfo structs.BuildInfo) error {
 	buildessend.Status = buildinfo.Status
 	buildessend.UpdatedAt = buildinfo.UpdatedAt
 	buildessend.Organization = buildinfo.Organization
-	spew.Dump(buildessend)
+	utils.PrintDebug(spew.Sdump(buildessend))
 	p, err := json.Marshal(buildessend)
 	if err != nil {
 		fmt.Println(err)

--- a/hooks/build.go
+++ b/hooks/build.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	akkeris "taas/jobs"
 	structs "taas/structs"
+	"taas/utils"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/martini-contrib/binding"
 	"github.com/martini-contrib/render"
@@ -46,7 +48,7 @@ func BuildHook(payload structs.BuildPayload, berr binding.Errors, r render.Rende
 func getBuildInfo(payload structs.BuildPayload) (b structs.BuildInfo, e error) {
 	var buildinfo structs.BuildInfo
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+payload.App.Name+"-"+payload.Space.Name+"/builds/"+payload.Build.ID, nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 	if err != nil {
 		fmt.Println(err)
 		return buildinfo, err
@@ -57,10 +59,10 @@ func getBuildInfo(payload structs.BuildPayload) (b structs.BuildInfo, e error) {
 		fmt.Println(err)
 		return buildinfo, err
 	}
-	fmt.Println(resp.Status)
+	utils.PrintDebug(resp.Status)
 	defer resp.Body.Close()
 	bb, err := ioutil.ReadAll(resp.Body)
-	fmt.Println(string(bb))
+	utils.PrintDebug(string(bb))
 	if err != nil {
 		fmt.Println(err)
 		return buildinfo, err
@@ -105,7 +107,7 @@ func writeBuildOutputES(buildinfo structs.BuildInfo) error {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	return nil
 }

--- a/hooks/preview.go
+++ b/hooks/preview.go
@@ -9,6 +9,7 @@ import (
 	githubapi "taas/githubapi"
 	akkeris "taas/jobs"
 	structs "taas/structs"
+	"taas/utils"
 
 	uuid "github.com/nu7hatch/gouuid"
 
@@ -55,7 +56,7 @@ func PreviewCreatedHook(previewcreatedhookpayload structs.PreviewCreatedHookSpec
 		return
 	}
 
-	fmt.Println("Starting to create diagnostic...")
+	utils.PrintDebug("Starting to create diagnostic...")
 
 	diagnostic, err := dbstore.FindPreviewParentDiagnostic(previewcreatedhookpayload.App.Name + "-" + previewcreatedhookpayload.Space.Name)
 	if err != nil || diagnostic.ID == "" {
@@ -127,7 +128,7 @@ func PreviewCreatedHook(previewcreatedhookpayload structs.PreviewCreatedHookSpec
 		fmt.Println(err)
 	}
 
-	fmt.Println("Diagnostic " + diagnostic.Job + " created for " + previewcreatedhookpayload.Preview.AppSetup.App.Name + "-" + previewcreatedhookpayload.Space.Name)
+	utils.PrintDebug("Diagnostic " + diagnostic.Job + " created for " + previewcreatedhookpayload.Preview.AppSetup.App.Name + "-" + previewcreatedhookpayload.Space.Name)
 
 	// Add destroy hook- clean up diagnostic once preview app is deleted
 	err = akkeris.CreateHook(true, []string{"destroy"}, os.Getenv("TAAS_SVC_URL")+"/v1/previewdestroyhook", "merpderp", previewcreatedhookpayload.Preview.App.Name)

--- a/hooks/release.go
+++ b/hooks/release.go
@@ -59,7 +59,7 @@ func ReleaseHookHandler(req *http.Request, releasehookpayload structs.ReleaseHoo
 		element.Organization = org
 		element.CommitAuthor = commitauthor
 		element.CommitMessage = commitmessage
-		spew.Dump(element)
+		utils.PrintDebug(spew.Sdump(element))
 		diagnostics.RunDiagnostic(element, isCron, structs.Cronjob{})
 	}
 

--- a/hooks/release.go
+++ b/hooks/release.go
@@ -2,16 +2,17 @@ package hooks
 
 import (
 	"fmt"
-	akkeris "taas/jobs"
+	"net/http"
 	diagnostics "taas/diagnostics"
 	githubapi "taas/githubapi"
+	akkeris "taas/jobs"
 	structs "taas/structs"
-        "net/http"
+	"taas/utils"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/martini-contrib/binding"
 	"github.com/martini-contrib/render"
 )
-
 
 func ReleaseHook(req *http.Request, releasehookpayload structs.ReleaseHookSpec, berr binding.Errors, r render.Render) {
 	if berr != nil {
@@ -19,28 +20,28 @@ func ReleaseHook(req *http.Request, releasehookpayload structs.ReleaseHookSpec, 
 		fmt.Println(berr)
 		return
 	}
-        ReleaseHookHandler(req, releasehookpayload, false)
+	ReleaseHookHandler(req, releasehookpayload, false)
 }
 
-func ReleaseHookHandler(req *http.Request, releasehookpayload structs.ReleaseHookSpec, isCron bool){
+func ReleaseHookHandler(req *http.Request, releasehookpayload structs.ReleaseHookSpec, isCron bool) {
 
-	fmt.Println(releasehookpayload.App.Name)
-	fmt.Println(releasehookpayload.Space.Name)
-	fmt.Println(releasehookpayload.Action)
-	fmt.Println(releasehookpayload.Release.Result)
+	utils.PrintDebug(releasehookpayload.App.Name)
+	utils.PrintDebug(releasehookpayload.Space.Name)
+	utils.PrintDebug(releasehookpayload.Action)
+	utils.PrintDebug(releasehookpayload.Release.Result)
 	diagnosticslist, err := diagnostics.GetDiagnostics(releasehookpayload.Space.Name, releasehookpayload.App.Name, releasehookpayload.Action, releasehookpayload.Release.Result)
 	if err != nil {
 		fmt.Println(err)
 	}
 	for _, element := range diagnosticslist {
-                element.ReleaseID = releasehookpayload.Release.ID
+		element.ReleaseID = releasehookpayload.Release.ID
 		element.BuildID = releasehookpayload.Build.ID
-                element.Token = req.Header.Get("x-akkeris-token")
+		element.Token = req.Header.Get("x-akkeris-token")
 		version, err := akkeris.GetVersion(element.App, element.Space, element.BuildID)
 		if err != nil {
 			fmt.Println(err)
 		}
-		fmt.Println(version)
+		utils.PrintDebug(version)
 		var commitauthor string
 		var commitmessage string
 		if version != "" {
@@ -49,7 +50,7 @@ func ReleaseHookHandler(req *http.Request, releasehookpayload structs.ReleaseHoo
 			if err != nil {
 				fmt.Println(err)
 			}
-			fmt.Println(commitauthor)
+			utils.PrintDebug(commitauthor)
 		} else {
 			commitauthor = "none"
 			commitmessage = "none"
@@ -59,7 +60,7 @@ func ReleaseHookHandler(req *http.Request, releasehookpayload structs.ReleaseHoo
 		element.CommitAuthor = commitauthor
 		element.CommitMessage = commitmessage
 		spew.Dump(element)
-		diagnostics.RunDiagnostic(element, isCron,structs.Cronjob{})
+		diagnostics.RunDiagnostic(element, isCron, structs.Cronjob{})
 	}
 
 }

--- a/jobs/apps.go
+++ b/jobs/apps.go
@@ -8,43 +8,45 @@ import (
 	"net/http"
 	"os"
 	structs "taas/structs"
+	"taas/utils"
 )
-func GetMostRecentReleaseID(diagnostic structs.DiagnosticSpec)(r string){
-        req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+diagnostic.App+"-"+diagnostic.Space+"/releases", nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
-        if err != nil {
-                fmt.Println(err)
-                return ""
-        }
-        client := http.Client{}
-        resp, err := client.Do(req)
-        if err != nil {
-                fmt.Println(err)
-                return ""
-        }
-        defer resp.Body.Close()
-        bodybytes, err := ioutil.ReadAll(resp.Body)
-        if err != nil {
-                fmt.Println(err)
-                return ""
-        }
-        var releases structs.Releases
-        err = json.Unmarshal(bodybytes, &releases)
-        if err != nil {
-                fmt.Println(err)
-                return ""
-        }
-        return releases[len(releases)-1].ID
-}               
+
+func GetMostRecentReleaseID(diagnostic structs.DiagnosticSpec) (r string) {
+	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+diagnostic.App+"-"+diagnostic.Space+"/releases", nil)
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	defer resp.Body.Close()
+	bodybytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	var releases structs.Releases
+	err = json.Unmarshal(bodybytes, &releases)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	return releases[len(releases)-1].ID
+}
 
 func GetVersion(app string, space string, buildid string) (s string, e error) {
 
-	fmt.Println(app)
-	fmt.Println(space)
-	fmt.Println(buildid)
+	utils.PrintDebug(app)
+	utils.PrintDebug(space)
+	utils.PrintDebug(buildid)
 
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+app+"-"+space+"/builds/"+buildid, nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 	if err != nil {
 		fmt.Println(err)
 		return "", err
@@ -62,14 +64,14 @@ func GetVersion(app string, space string, buildid string) (s string, e error) {
 			fmt.Println(err)
 			return "", err
 		}
-		fmt.Println(string(bodybytes))
+		utils.PrintDebug(string(bodybytes))
 		var buildinfo structs.BuildSpec
 		err = json.Unmarshal(bodybytes, &buildinfo)
 		if err != nil {
 			fmt.Println(err)
 			return "", err
 		}
-		fmt.Println(buildinfo.SourceBlob.Version)
+		utils.PrintDebug(buildinfo.SourceBlob.Version)
 		return buildinfo.SourceBlob.Version, nil
 	} else {
 		return "", nil
@@ -80,7 +82,7 @@ func GetVersion(app string, space string, buildid string) (s string, e error) {
 func GetAppControllerOrg(app string) (o string, e error) {
 	var org string
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/v1/apps/"+app, nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 	if err != nil {
 		fmt.Println(err)
 		return org, err
@@ -100,22 +102,22 @@ func GetAppControllerOrg(app string) (o string, e error) {
 		fmt.Println(err)
 		return org, err
 	}
-	fmt.Println(string(bb))
+	utils.PrintDebug(string(bb))
 	var appcontrollerapp structs.AppControllerApp
 	err = json.Unmarshal(bb, &appcontrollerapp)
 	if err != nil {
 		fmt.Println(err)
 		return org, err
 	}
-	fmt.Println(appcontrollerapp.Organization.Name)
+	utils.PrintDebug(appcontrollerapp.Organization.Name)
 	org = appcontrollerapp.Organization.Name
 	return org, nil
 }
 
 func IsValidSpace(space string) (v bool, e error) {
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/spaces/"+space, nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
-        if err != nil {
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	if err != nil {
 		fmt.Println(err)
 		return false, err
 	}
@@ -134,16 +136,14 @@ func IsValidSpace(space string) (v bool, e error) {
 
 func IsProtectedSpace(space string) (p bool, err error) {
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/spaces/"+space, nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 	if err != nil {
-		fmt.Println("1")
 		fmt.Println(err)
 		return false, err
 	}
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println("2")
 		fmt.Println(err)
 		return false, err
 	}
@@ -151,13 +151,11 @@ func IsProtectedSpace(space string) (p bool, err error) {
 	defer resp.Body.Close()
 	bodybytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println("3")
 		fmt.Println(err)
 		return false, err
 	}
 	err = json.Unmarshal(bodybytes, &spaceinfo)
 	if err != nil {
-		fmt.Println("4")
 		fmt.Println(err)
 		return false, err
 	}
@@ -173,7 +171,7 @@ func IsProtectedSpace(space string) (p bool, err error) {
 
 func GetHooks(app string) (h []structs.AppHook, e error) {
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+app+"/hooks", nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
@@ -208,7 +206,7 @@ func GetHooks(app string) (h []structs.AppHook, e error) {
 
 func DeleteHook(app string, hookid string) (e error) {
 	req, err := http.NewRequest("DELETE", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+"app"+"/hooks/"+hookid, nil)
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -225,6 +223,6 @@ func DeleteHook(app string, hookid string) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 }

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
+	"strconv"
 	"strings"
 	structs "taas/structs"
+	"taas/utils"
 
 	_ "github.com/lib/pq"
 	uuid "github.com/nu7hatch/gouuid"
@@ -23,7 +26,7 @@ func UpdateService(diagnosticspec structs.DiagnosticSpec) (e error) {
 		fmt.Println(dberr)
 	}
 	defer db.Close()
-	fmt.Println(diagnosticspec.Slackchannel)
+	utils.PrintDebug(diagnosticspec.Slackchannel)
 	stmt, err := db.Prepare("UPDATE diagnostics set image=$1,pipelinename=$2,transitionfrom=$3,transitionto=$4,timeout=$5,startdelay=$6,slackchannel=$7,command=$8,testpreviews=$9,webhookurls=$10 where job=$11 and jobspace=$12")
 	if err != nil {
 		fmt.Println(err)
@@ -45,7 +48,7 @@ func UpdateService(diagnosticspec structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(rowCnt)
+	utils.PrintDebug(rowCnt)
 	return nil
 }
 
@@ -113,7 +116,7 @@ func CreateBind(diagnosticspec structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 }
 
@@ -153,7 +156,7 @@ func CreateConfigSet(diagnosticspec structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 }
 
@@ -231,7 +234,7 @@ func CreateVariables(diagnosticspec structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 }
 
@@ -264,7 +267,7 @@ func UpdateVar(vartoadd structs.Varspec) error {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	return nil
 }
@@ -301,7 +304,7 @@ func AddVar(vartoadd structs.Varspec) error {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	return nil
 }
@@ -316,7 +319,8 @@ func DeleteVar(diagnosticspec structs.DiagnosticSpec, varname string) error {
 	}
 	req.Header.Add("Content-type", "application/json")
 	client := http.Client{}
-	fmt.Println(req)
+	requestDump, _ := httputil.DumpRequest(req, false)
+	utils.PrintDebug(string(requestDump))
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Println(err)
@@ -328,7 +332,7 @@ func DeleteVar(diagnosticspec structs.DiagnosticSpec, varname string) error {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 
 	return nil
 }
@@ -357,7 +361,7 @@ func DeleteService(diagnostic structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(affect)
+	utils.PrintDebug(strconv.FormatInt(affect, 10))
 
 	db.Close()
 
@@ -387,7 +391,7 @@ func DeleteBind(diagnostic structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 
 }
@@ -415,7 +419,7 @@ func DeleteSet(diagnostic structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 
 }
@@ -441,7 +445,7 @@ func DeleteJob(diagnostic structs.DiagnosticSpec) (e error) {
 		fmt.Println(err)
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 
 }
@@ -517,12 +521,12 @@ func CreateHooks(appspace string) (e error) {
 		return errors.New("One or more hooks failed to create: " + strings.Join(failedHooks, ","))
 	}
 
-	fmt.Println("All hooks present!")
+	utils.PrintDebug("All hooks present!")
 	return nil
 }
 
 func CreatePreviewHooks(appspace string) (e error) {
-	fmt.Println("Creating preview hooks...")
+	utils.PrintDebug("Creating preview hooks...")
 	svcurl := os.Getenv("TAAS_SVC_URL")
 	var failedHooks []string
 
@@ -564,7 +568,7 @@ func CreatePreviewHooks(appspace string) (e error) {
 		return errors.New("One or more hooks failed to create: " + strings.Join(failedHooks, ","))
 	}
 
-	fmt.Println("All preview hooks present!")
+	utils.PrintDebug("All preview hooks present!")
 	return nil
 }
 
@@ -598,12 +602,12 @@ func CreateHook(active bool, events []string, url string, secret string, app str
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(bodybytes))
+	utils.PrintDebug(string(bodybytes))
 	return nil
 }
 
 func DeletePreviewHooks(appspace string) (e error) {
-	fmt.Println("Deleting preview hooks...")
+	utils.PrintDebug("Deleting preview hooks...")
 	svcurl := os.Getenv("TAAS_SVC_URL")
 
 	hooks, err := GetHooks(appspace)

--- a/notifications/postback.go
+++ b/notifications/postback.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	structs "taas/structs"
+	"taas/utils"
 )
 
 func PostResults(result structs.ResultSpec) (e error) {
@@ -21,7 +22,7 @@ func PostResults(result structs.ResultSpec) (e error) {
 		postbackurl := os.Getenv("POSTBACKURL")
 		postbacks := strings.Split(postbackurl, ",")
 		for _, postback := range postbacks {
-			fmt.Println("Posting to " + postback)
+			utils.PrintDebug("Posting to " + postback)
 			req, err := http.NewRequest("POST", postback, bytes.NewBuffer(p))
 			if err != nil {
 				fmt.Println(err)
@@ -40,8 +41,8 @@ func PostResults(result structs.ResultSpec) (e error) {
 				fmt.Println(err)
 				return err
 			}
-			fmt.Println("Response body from postback: " + string(bodybytes))
-			fmt.Println("Response code from postback: " + resp.Status)
+			utils.PrintDebug("Response body from postback: " + string(bodybytes))
+			utils.PrintDebug("Response code from postback: " + resp.Status)
 		}
 	}
 	return nil

--- a/notifications/slack.go
+++ b/notifications/slack.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	structs "taas/structs"
+	"taas/utils"
 	"time"
 )
 
@@ -36,9 +37,9 @@ func PostToSlack(diagnostic structs.DiagnosticSpec, status string, promotestatus
 	var slack Slack
 	testframework := strings.ToUpper(strings.Split(strings.Replace(diagnostic.Image, "quay.octanner.io/developer/", "", -1), ":")[0])
 
-	fmt.Println("********************************")
-	fmt.Println(testframework)
-	fmt.Println("********************************")
+	utils.PrintDebug("********************************")
+	utils.PrintDebug(testframework)
+	utils.PrintDebug("********************************")
 	if diagnostic.Slackchannel != "" {
 		slack.Channel = diagnostic.Slackchannel
 	}
@@ -66,7 +67,7 @@ func PostToSlack(diagnostic structs.DiagnosticSpec, status string, promotestatus
 	if diagnostic.GithubVersion != "" {
 		slack.Text = slack.Text + "<" + diagnostic.GithubVersion + "|Commit>  "
 	}
-	slack.Text = slack.Text + "<" + os.Getenv("RERUN_URL") + "?space=" + diagnostic.Space + "&app=" + diagnostic.App + "&action=" + diagnostic.Action + "&result=" + diagnostic.Result + "&releaseid="+diagnostic.ReleaseID + "&buildid=" + diagnostic.BuildID + "|Rerun>\n"
+	slack.Text = slack.Text + "<" + os.Getenv("RERUN_URL") + "?space=" + diagnostic.Space + "&app=" + diagnostic.App + "&action=" + diagnostic.Action + "&result=" + diagnostic.Result + "&releaseid=" + diagnostic.ReleaseID + "&buildid=" + diagnostic.BuildID + "|Rerun>\n"
 	slack.Text = slack.Text + "Changes Made by: @" + diagnostic.CommitAuthor
 	slack.UnfurlLinks = false
 	slack.UnfurlMedia = false
@@ -77,10 +78,10 @@ func PostToSlack(diagnostic structs.DiagnosticSpec, status string, promotestatus
 		slack.IconEmoji = ":metal:"
 		attachment.Color = "good"
 		attachment.Text = "OK"
-        } else if status == "timedout" {
-                slack.IconEmoji = ":grey_question:"
-                attachment.Color = "warning"
-                attachment.Text = "TIMEDOUT"
+	} else if status == "timedout" {
+		slack.IconEmoji = ":grey_question:"
+		attachment.Color = "warning"
+		attachment.Text = "TIMEDOUT"
 	} else {
 		slack.IconEmoji = ":poop:"
 		attachment.Color = "danger"
@@ -97,7 +98,7 @@ func PostToSlack(diagnostic structs.DiagnosticSpec, status string, promotestatus
 		fmt.Println(err)
 
 	}
-	fmt.Println(slack.Text)
+	utils.PrintDebug(slack.Text)
 	if os.Getenv("ENABLE_SLACK_NOTIFICATIONS") == "true" {
 		req, err := http.NewRequest("POST", slackurl, bytes.NewBuffer(p))
 		if err != nil {
@@ -111,10 +112,10 @@ func PostToSlack(diagnostic structs.DiagnosticSpec, status string, promotestatus
 		}
 		defer resp.Body.Close()
 		bodybytes, err := ioutil.ReadAll(resp.Body)
-		fmt.Println(string(bodybytes))
-                if !isCron{ 
-	        	PostPromoteToSlack(diagnostic, status, promotestatus)
-                }
+		utils.PrintDebug(string(bodybytes))
+		if !isCron {
+			PostPromoteToSlack(diagnostic, status, promotestatus)
+		}
 	}
 	if os.Getenv("ENABLE_DEBUG_SLACK_NOTIFICATIONS") == "true" {
 		debugslackurl := os.Getenv("DEBUG_SLACK_NOTIFICATION_URL")
@@ -130,7 +131,7 @@ func PostToSlack(diagnostic structs.DiagnosticSpec, status string, promotestatus
 		}
 		defer resp.Body.Close()
 		bodybytes, err := ioutil.ReadAll(resp.Body)
-		fmt.Println(string(bodybytes))
+		utils.PrintDebug(string(bodybytes))
 	}
 }
 
@@ -175,7 +176,7 @@ func PostPromoteToSlack(diagnostic structs.DiagnosticSpec, status string, promot
 		fmt.Println(err)
 
 	}
-	fmt.Println(slack.Text)
+	utils.PrintDebug(slack.Text)
 
 	if os.Getenv("ENABLE_SLACK_NOTIFICATIONS") == "true" {
 		req, err := http.NewRequest("POST", slackurl, bytes.NewBuffer(p))
@@ -190,7 +191,7 @@ func PostPromoteToSlack(diagnostic structs.DiagnosticSpec, status string, promot
 		}
 		defer resp.Body.Close()
 		bodybytes, err := ioutil.ReadAll(resp.Body)
-		fmt.Println(string(bodybytes))
+		utils.PrintDebug(string(bodybytes))
 	}
 
 }

--- a/pipelines/pipelines.go
+++ b/pipelines/pipelines.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	structs "taas/structs"
+	"taas/utils"
 )
 
 func GetPipeline(pipelinename string) (p structs.PipelineSpec, e error) {
@@ -19,7 +20,7 @@ func GetPipeline(pipelinename string) (p structs.PipelineSpec, e error) {
 		return pipeline, err
 	}
 	req.Header.Add("Content-type", "application/json")
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 
 	client := http.Client{}
 	resp, err := client.Do(req)
@@ -56,7 +57,7 @@ func PromoteApp(promotion structs.PromotionSpec) (s string, e error) {
 		return "failed", err
 	}
 	req.Header.Add("Content-type", "application/json")
-        req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
+	req.Header.Set("Authorization", os.Getenv("APP_CONTROLLER_AUTH"))
 
 	client := http.Client{}
 	resp, err := client.Do(req)
@@ -70,13 +71,13 @@ func PromoteApp(promotion structs.PromotionSpec) (s string, e error) {
 		fmt.Println(err)
 		return "failed", err
 	}
-	fmt.Println(string(bodybytes))
-        var promotestatus structs.PromoteStatus
-        err = json.Unmarshal(bodybytes, &promotestatus)
-        if err != nil {
-                fmt.Println(err)
-                return  "failed.  "+string(bodybytes),  err
-        }
+	utils.PrintDebug(string(bodybytes))
+	var promotestatus structs.PromoteStatus
+	err = json.Unmarshal(bodybytes, &promotestatus)
+	if err != nil {
+		fmt.Println(err)
+		return "failed.  " + string(bodybytes), err
+	}
 
 	return promotestatus.Status, nil
 }

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 	hooks "taas/hooks"
 	jobs "taas/jobs"
 	structs "taas/structs"
+	"taas/utils"
 
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/binding"
@@ -97,7 +98,7 @@ func main() {
 		dbstore.FindCronOrphans()
 	}
 
-	m := martini.Classic()
+	m := utils.CreateClassicMartini()
 	m.Use(render.Renderer())
 	m.Post("/v1/releasehook", binding.Json(structs.ReleaseHookSpec{}), hooks.ReleaseHook)
 	m.Post("/v1/buildhook", binding.Json(structs.BuildPayload{}), hooks.BuildHook)

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	artifacts "taas/artifacts"
 	cronjobs "taas/cronjobs"
+	"taas/cronworker"
 	dbstore "taas/dbstore"
 	diagnosticlogs "taas/diagnosticlogs"
 	diagnostics "taas/diagnostics"
@@ -63,13 +64,32 @@ func createDB() {
 	}
 }
 
+func isCronWorker() bool {
+	for _, v := range os.Args[1:] {
+		if v == "--cron_worker" {
+			return true
+		}
+	}
+	return false
+}
+
 func main() {
 	checkEnv()
 	createDB()
 	dbstore.InitAuditPool()
 	dbstore.InitCronjobPool()
 	artifacts.Init()
-	cronjobs.StartCron()
+	jobs.StartClient()
+
+	if isCronWorker() {
+		cronworker.Start()
+		return
+	}
+
+	// Not using new cron worker
+	if os.Getenv("ENABLE_CRON_WORKER") == "" {
+		cronjobs.StartCron()
+	}
 
 	// Mark orphan jobs (env should be set if running in production)
 	if os.Getenv("FIND_ORPHANS") != "" {
@@ -77,7 +97,6 @@ func main() {
 		dbstore.FindCronOrphans()
 	}
 
-	jobs.StartClient()
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/v1/releasehook", binding.Json(structs.ReleaseHookSpec{}), hooks.ReleaseHook)
@@ -121,6 +140,11 @@ func main() {
 	m.Get("/v1/cronjob/:id/runs", cronjobs.GetCronjobRuns)
 
 	m.Get("/v1/status/runs", diagnostics.GetCurrentRuns)
+
+	if os.Getenv("ENABLE_CRON_WORKER") != "" {
+		m.Get("/v1/cronjob/:id", cronjobs.GetCronjob)
+		m.Patch("/v1/cronjob/:id", binding.Json(structs.Cronjob{}), cronjobs.UpdateCronjob)
+	}
 
 	m.Use(martini.Static("static"))
 	m.Run()

--- a/start.sh
+++ b/start.sh
@@ -4,4 +4,10 @@ if [ -f /var/run/secrets/kubernetes.io/serviceaccount/ca.crt ]
 then
    cat  /var/run/secrets/kubernetes.io/serviceaccount/ca.crt >> /etc/ssl/certs/ca-certificates.crt
 fi
-/go/src/taas/taas
+
+if [[ -n "$1" && "$1" == "cron" ]]
+then
+    /go/src/taas/taas --cron_worker
+else
+   /go/src/taas
+fi

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -908,8 +908,9 @@ type Cronjob struct {
 	ID       string    `json:"id"`
 	Job      string    `json:"job"`
 	Jobspace string    `json:"jobspace"`
-	Cronspec string    `json:"cs"`
+	Cronspec string    `json:"cronspec"`
 	Command  string    `json:"command"`
+	Disabled bool      `json:"disabled"`
 	Prev     time.Time `json:"prev"`
 	Next     time.Time `json:"next"`
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,11 +2,72 @@ package utils
 
 import (
 	"fmt"
+	"log"
+	"net/http"
 	"os"
+	"time"
+
+	"github.com/go-martini/martini"
 )
 
+// PrintDebug prints message if DEBUG=true
 func PrintDebug(msg interface{}) {
 	if os.Getenv("DEBUG") != "" {
 		fmt.Println(msg)
 	}
+}
+
+/*
+	The following functions are to avoid tons of output in the logs
+	from people accessing the "currently running tests" webpage
+*/
+
+var ignoredRoutes = []string{"/v1/status/runs"}
+
+func ignoreRoute(path string) bool {
+	for _, route := range ignoredRoutes {
+		if path == route {
+			return true
+		}
+	}
+	return false
+}
+
+// CustomLogger prints HTTP server info for Martini while ignoring certain routes
+func CustomLogger() martini.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c martini.Context, log *log.Logger) {
+		if ignoreRoute(req.URL.Path) {
+			return
+		}
+
+		start := time.Now()
+
+		addr := req.Header.Get("X-Real-IP")
+		if addr == "" {
+			addr = req.Header.Get("X-Forwarded-For")
+			if addr == "" {
+				addr = req.RemoteAddr
+			}
+		}
+
+		log.Printf("Started %s %s for %s", req.Method, req.URL.Path, addr)
+
+		rw := res.(martini.ResponseWriter)
+		c.Next()
+
+		log.Printf("Completed %v %s in %v\n", rw.Status(), http.StatusText(rw.Status()), time.Since(start))
+	}
+}
+
+// CreateClassicMartini returns a new ClassicMartini instance with a custom logger
+func CreateClassicMartini() *martini.ClassicMartini {
+	r := martini.NewRouter()
+	m := martini.New()
+	m.Use(CustomLogger())
+	m.Use(martini.Recovery())
+	m.Use(martini.Static("public"))
+	m.MapTo(r, (*martini.Routes)(nil))
+	m.Action(r.Handle)
+
+	return &martini.ClassicMartini{Martini: m, Router: r}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+func PrintDebug(msg interface{}) {
+	if os.Getenv("DEBUG") != "" {
+		fmt.Println(msg)
+	}
+}


### PR DESCRIPTION
Oh boy, this one is a bit of a doozy...

**Add "cron worker" functionality**
- The cron worker is responsible for the actual scheduling and running of cronjobs. 
- It needs to be deployed as a secondary pod (maximum of 1). An example manifest is provided.
- Any actual configuration of cronjobs are done in the main Taas pod(s). The worker listens for changes in the database and updates the cron scheduler.
- This eliminates any race condition, concurrency, and scaling issues as well as splitting off cron runs to make debugging and monitoring easier
- To use the cron worker, set the `ENABLE_CRON_WORKER` environment variable to true. 
  - If someone updates Taas and doesn't have this environment variable set, cron will continue to work as it has been up to this point. 
  - Hopefully this should make migration less painful
- To run the cron worker, add the `--cron_worker` argument to the command line when running Taas

**Reduce logging**
- Added a `utils` package with a `PrintDebug` function.
- If `DEBUG=true` environment variable is set, Taas will spit out copious amounts of debug logs (the way it has always done)
- Otherwise, things will be nice and quiet (except for errors) with only HTTP route info and one or two info messages per run.
- Also, Taas now doesn't spit any HTTP route info when the currently running page is visited. This is to cut back on logs that would constantly be spit out whenever anyone visited the page

**Minor linting/go-fmt changes**
- Might want to turn off whitespace changes when viewing code changes in this PR

