### PR TITLE
COBRA-3746: golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,28 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,12 +11,3 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,5 @@
 name: golangci-lint
-on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-  pull_request:
+on: [push]
 jobs:
   golangci:
     name: lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  disable-all: true
+  enable:
+    - gofmt

--- a/artifacts/list.go
+++ b/artifacts/list.go
@@ -60,8 +60,8 @@ var (
 	c       *config
 )
 
-func Init(){
-        c = configFromEnvironmentVariables()
+func Init() {
+	c = configFromEnvironmentVariables()
 }
 
 func configFromEnvironmentVariables() *config {
@@ -465,9 +465,9 @@ func s3listFiles(w http.ResponseWriter, r *http.Request, backet, key string) {
 			}
 			html += "</li>"
 		}
-                if (len(files)==0) {
-                        html += "<h3>No Artifacts</h3>"
-                }
+		if len(files) == 0 {
+			html += "<h3>No Artifacts</h3>"
+		}
 		html += "</ul></font></body></html>"
 		fmt.Fprintln(w, html)
 		return

--- a/jobs/apps.go
+++ b/jobs/apps.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"os"
 	structs "taas/structs"
-	"taas/utils"
+	"taas/utils"  
 )
+
 
 func GetMostRecentReleaseID(diagnostic structs.DiagnosticSpec) (r string) {
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+diagnostic.App+"-"+diagnostic.Space+"/releases", nil)

--- a/jobs/apps.go
+++ b/jobs/apps.go
@@ -8,9 +8,8 @@ import (
 	"net/http"
 	"os"
 	structs "taas/structs"
-	"taas/utils"  
+	"taas/utils"
 )
-
 
 func GetMostRecentReleaseID(diagnostic structs.DiagnosticSpec) (r string) {
 	req, err := http.NewRequest("GET", os.Getenv("APP_CONTROLLER_URL")+"/apps/"+diagnostic.App+"-"+diagnostic.Space+"/releases", nil)


### PR DESCRIPTION
Run `gofmt` on CI via GH Actions. 

The golangci-lint-action GH action will also leave nice annotations on the files changed view ([example](https://github.com/akkeris/taas/pull/45/files/de0b14178d473c00463251a4d7707baf12176418)).