### PR TITLE
COBRA-3975: Create webhook on update

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -49,6 +49,13 @@ func UpdateService(diagnosticspec structs.DiagnosticSpec) (e error) {
 		return err
 	}
 	utils.PrintDebug(rowCnt)
+
+	err = CreateHooks(diagnosticspec.App + "-" + diagnosticspec.Space)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
On the last PR I forgot that we need to create the new `released` webhook when changing the `action`.

Potential concerns:
- This will run `CreateHooks` on each update, even if the `action` attribute is not changed. I think this is fine, since that method is idempotent, so running it again won't hurt.
- This does not delete the old webhook, but neither does deleting a diagnostic, so that was a previous known issue.

Let me know if this seems fine or if you think I should fix one or both of these.