### PR TITLE
COBRA-4184: Set default config var to help with results reporting

### DIFF
--- a/diagnostics/diagnostics.go
+++ b/diagnostics/diagnostics.go
@@ -95,6 +95,12 @@ func RunDiagnostic(diagnostic structs.DiagnosticSpec, isCron bool, cronjob struc
 	akkeris.AddVar(newvar)
 	akkeris.UpdateVar(newvar)
 
+	newvar.Setname = diagnostic.Job + "-" + diagnostic.JobSpace + "-cs"
+	newvar.Varname = "ORIGIN"
+	newvar.Varvalue = "taas"
+	akkeris.AddVar(newvar)
+	akkeris.UpdateVar(newvar)
+
 	go check(diagnostic, isCron, cronjob)
 	return nil
 }


### PR DESCRIPTION
I tested this locally by triggering a new TaaS test, then `exec`ing into the pod in Maru and confirming that the env var `ORIGIN=taas` was set by default.