### PR TITLE
fix for slice out of bounds on getStatusCheck

### DIFF
--- a/diagnostics/diagnostics.go
+++ b/diagnostics/diagnostics.go
@@ -144,7 +144,10 @@ func getStatusCheck(diagnostic structs.DiagnosticSpec) (c string, e error) {
 	for _, status := range statuses.Statuses {
 		utils.PrintDebug(status.ID)
 		testContext := "taas/" + diagnostic.Job + "-" + diagnostic.JobSpace
-		if status.Context == testContext || status.Context == testContext[:28]+"..." {
+		if len(testContext) >= 32 {
+			testContext = testContext[:28] + "..."
+		}
+		if status.Context == testContext {
 			statusid = status.ID
 		}
 	}


### PR DESCRIPTION
The status check context is truncated to a length of 32 characters in cases where it exceeds that length. This makes sure that in the case that the context is less than 32 characters, it does not attempt to do the truncation when doing a string comparison.